### PR TITLE
Рейты для бесшумного пистолета

### DIFF
--- a/protection/rapidfire.inc
+++ b/protection/rapidfire.inc
@@ -82,8 +82,8 @@ static
 		},
 		// WEAPONSKILL_PISTOL_SILENCED
 		{
-			{40, 280},
-			{999, 160}
+			{40, 380},
+			{999, 360}
 		},
 		// WEAPONSKILL_DESERT_EAGLE
 		{


### PR DESCRIPTION
Кажется, рейты для бесшумного пистолета были спутаны с рейтами для обычного и продублированы с него.